### PR TITLE
Add "includes" to BUILD file to fix system include path for bazel 5 or newer

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -4,6 +4,7 @@ cc_library(
     srcs = ["death_handler.cc"],
     hdrs = ["death_handler.h"],
     include_prefix = "",
+    includes = [""],
     strip_include_prefix = "",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
When building using bazel 5.0.0 or newer, `death_handler.h` could not be included using angle brackets because, without an `includes` entry in the BUILD file, the include path was only being included via `-iquote`.  So now an `includes` entry has been added to the BUILD file.

This change has been tested to work when building both under bazel 4.2.2 and bazel 6.4.0.
